### PR TITLE
Correct msDS-ManagedAccountPrecededByLink type to multi_str

### DIFF
--- a/badldap/protocol/typeconversion.py
+++ b/badldap/protocol/typeconversion.py
@@ -418,7 +418,7 @@ MSLDAP_BUILTIN_ATTRIBUTE_TYPES_ENC = {
 	'nTSecurityDescriptor' : single_bytes,
 	#'msPKI-Certificate-Name-Flag' : single_int,
 	"msDS-DelegatedMSAState" : single_int,
-	"msDS-ManagedAccountPrecededByLink" : single_str,
+	"msDS-ManagedAccountPrecededByLink" : multi_str,
 	"msDS-ManagedPasswordInterval" : single_int,
 	"msDS-SupportedEncryptionTypes" : single_int,
 	"msDS-GroupMSAMembership" : single_sd,


### PR DESCRIPTION
The `msDS-ManagedAccountPrecededByLink` attribute encoding type being set to `single_str` breaks when the badSuccessor bloodyAD module is called and this corrects it.

This is the fix pulled from the following comment in the relevant issue:

https://github.com/CravateRouge/bloodyAD/issues/101#issuecomment-3536876614

I do not know if this is used elsewhere that will break, but from what I saw in the little bit of looking I did it seems that the only place this is currently relevant is in bloodyAD's badSuccessor module, but I could be wrong and apologize if I am!